### PR TITLE
Fix Non-Updating Tokens When Retrying Requests

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ cd Cyber-Prepa-Front
 Install the necessary packages via:
 
 ```bash
-npm install
+pnpm install
 ```
 
 ### Run the development server
@@ -47,7 +47,7 @@ npm install
 Run the server via:
 
 ```bash
-npm run dev
+pnpm dev
 ```
 
 ### Set environment variables
@@ -71,7 +71,7 @@ To deploy the app, you must turn on the IIS feature on your Windows machine.
 Run the following command to build the app.
 
 ```bash
-npm run build
+pnpm build
 ```
 
 This will create a `dist` folder in the root of the project.

--- a/src/components/AddStudentButton/AddStudentButton.tsx
+++ b/src/components/AddStudentButton/AddStudentButton.tsx
@@ -1,9 +1,10 @@
-import React, { CSSProperties, useEffect, useState } from 'react';
+import React, { CSSProperties, useState } from 'react';
 import { Game, PlayResponse } from '../../services/types';
 import { createPlay } from '../../services';
 import { Loading } from '..';
 import { Box, Button, TextField } from '@mui/material';
 import { SnackbarComponent } from '../SnackbarComponent';
+import { useAppContext } from '../../store/appContext/useAppContext';
 
 interface AddStudentProps {
   cardGame: Game;
@@ -11,21 +12,13 @@ interface AddStudentProps {
 }
 
 const AddStudentButton: React.FC<AddStudentProps> = ({ cardGame, style }) => {
+  const { tokens } = useAppContext();
   const [studentId, setStudentId] = useState<string>("");
   const [isLoading, setIsLoading] = useState<boolean>(false);
   const [open, setOpen] = React.useState(false);
   const [openSuccess, setOpenSuccess] = React.useState(false);
   const [alertMessage, setAlertMessage] = useState('');
-  const [accessToken, setAccessToken] = useState<string>('');
   const [inputState, setInputState] = useState<'error' | 'success' | 'standard'>('standard');
-
-  useEffect(() => {
-    const tokensString = localStorage.getItem('tokens');
-    if (tokensString) {
-      const tokens = JSON.parse(tokensString);
-      setAccessToken(tokens.access_token);
-    }
-  }, []);
 
   const regexPattern = /^[Aa]\d{8}$/;
 
@@ -50,7 +43,7 @@ const AddStudentButton: React.FC<AddStudentProps> = ({ cardGame, style }) => {
   const addStudent = async (studentId: string) => {
     try {
       setIsLoading(true);
-      const response: PlayResponse = await createPlay(false, studentId.toLowerCase(), cardGame.id, accessToken);
+      const response: PlayResponse = await createPlay(false, studentId.toLowerCase(), cardGame.id, tokens?.access_token || '');
 
       if (response.detail === 'Invalid student id') {
         setAlertMessage('Matricula inválida, vuelve a intentarlo');

--- a/src/components/CardExpander/CardExpander.tsx
+++ b/src/components/CardExpander/CardExpander.tsx
@@ -7,12 +7,10 @@ import React, { CSSProperties } from 'react';
 
 interface CardExpanderProps {
   cardGame: Game;
-  shouldUpdate: boolean;
-  onUpdated(): void;
   countdownStatus: string;
 }
 
-const CardExpander: React.FC<CardExpanderProps> = ({ cardGame, shouldUpdate, onUpdated, countdownStatus }) => {
+const CardExpander: React.FC<CardExpanderProps> = ({ cardGame, countdownStatus }) => {
 
   const isGameActive = countdownStatus !== "AGOTADO";
   const showEndPlayForAllButton = Array.isArray(cardGame.plays) && cardGame.plays.length >= 1;
@@ -33,8 +31,6 @@ const CardExpander: React.FC<CardExpanderProps> = ({ cardGame, shouldUpdate, onU
       </Box>
       <CollapsedStudents
         cardGame={cardGame}
-        shouldUpdate={shouldUpdate}
-        onUpdated={onUpdated}
         isGameActive={isGameActive}
       />
     </div>

--- a/src/components/CollapsedStudents/CollapsedStudents.tsx
+++ b/src/components/CollapsedStudents/CollapsedStudents.tsx
@@ -1,77 +1,26 @@
-import { useEffect, useState } from "react";
 import { CollapsedStudentItem } from "..";
-import { readGameById } from "../../services";
-import { Game, Play } from "../../services/types";
-import { SnackbarComponent } from "../SnackbarComponent";
+import { Game } from "../../services/types";
 
 interface CollapsedStudentProps {
   cardGame: Game;
-  shouldUpdate: boolean;
-  onUpdated(): void;
   isGameActive: boolean;
 }
 
-const CollapsedStudents: React.FC<CollapsedStudentProps> = ({ cardGame, shouldUpdate, onUpdated, isGameActive }) => {
-
-  const [studentsData, setStudentsData] = useState<Play[] | number>(cardGame.plays);
-  const [open, setOpen] = useState(false);
-  const [alertMessage, setAlertMessage] = useState('');
-  const [accessToken, setAccessToken] = useState<string>('');
-
-  useEffect(() => {
-    const tokensString = localStorage.getItem('tokens');
-    if (tokensString) {
-      const tokens = JSON.parse(tokensString);
-      setAccessToken(tokens.access_token);
-    }
-  }, []);
-
-  useEffect(() => {
-    const fetchUpdatedGame = async () => {
-      if (shouldUpdate) {
-        try {
-          const res = await readGameById(cardGame.id, accessToken)
-          if (res && res.data) {
-            setStudentsData(res.data.plays);
-            onUpdated()
-          }
-        } catch (error) {
-          setAlertMessage('Error actualizando la data del juego, porfavor refresca la página');
-          setOpen(true);
-        }
-      }
-    }
-    if (shouldUpdate) {
-      fetchUpdatedGame()
-    }
-  }, [shouldUpdate, cardGame.id, accessToken, onUpdated])
-
-  const handleClose = (_event?: React.SyntheticEvent | Event, reason?: string) => {
-    if (reason === 'clickaway') {
-      return;
-    }
-    setOpen(false);
-  };
+const CollapsedStudents: React.FC<CollapsedStudentProps> = ({ cardGame, isGameActive }) => {
 
   return (
     <div className="collapsed__students">
       
       <ul id={`cyber__student__list__${cardGame.id}`} className="container__dropzone">
-        {typeof studentsData === 'number' ? (
-          <p>No estás autorizado para ver la data de los {studentsData} jugadores</p>
+        {typeof cardGame.plays === 'number' ? (
+          <p>No estás autorizado para ver la data de los {cardGame.plays} jugadores</p>
         ) : (
-          studentsData.map((player) => (
+          cardGame.plays.map((player) => (
             <CollapsedStudentItem key={player.id} player={player} cardGameId={cardGame.id} isGameActive={isGameActive} notices={player.notices} owedMaterials={player.owed_materials}/>
           ))
         )}
       </ul>
 
-      <SnackbarComponent
-        open={open}
-        onClose={handleClose}
-        severity="warning"
-        message={alertMessage}
-      />
     </div>
   );
 };

--- a/src/components/EndPlayButton/EndPlayButton.tsx
+++ b/src/components/EndPlayButton/EndPlayButton.tsx
@@ -1,10 +1,11 @@
+import { Rule } from "@mui/icons-material";
 import { IconButton, Tooltip } from "@mui/material";
+import Alert from "@mui/material/Alert";
+import Snackbar from "@mui/material/Snackbar";
+import { useState } from "react";
 import { patchPlayById } from "../../services";
 import { Play } from "../../services/types";
-import { useEffect, useState } from "react";
-import Snackbar from "@mui/material/Snackbar";
-import Alert from "@mui/material/Alert";
-import { Rule } from "@mui/icons-material";
+import { useAppContext } from "../../store/appContext/useAppContext";
 
 interface EndPlayButtonProps {
   player: Play;
@@ -15,30 +16,14 @@ interface EndPlayButtonProps {
 
 const EndPlayButton: React.FC<EndPlayButtonProps> = ({ player, cardGameId, isGameActive }) => {
 
+  const { tokens } = useAppContext();
   const [open, setOpen] = useState(false);
   const [openSuccess, setOpenSuccess] = useState(false);
   const [alertMessage, setAlertMessage] = useState("");
-  const [accessToken, setAccessToken] = useState<string | undefined>(undefined);
-
-  useEffect(() => {
-    const tokensString = localStorage.getItem('tokens');
-    if (tokensString) {
-      const tokens = JSON.parse(tokensString);
-      setAccessToken(tokens.access_token);
-    }
-  }, []);
-
-  useEffect(() => {
-    const tokensString = localStorage.getItem('tokens');
-    if (tokensString) {
-      const tokens = JSON.parse(tokensString);
-      setAccessToken(tokens.access_token);
-    }
-  }, []);
 
   const handleEndPlay = async () => {
     try {
-      await patchPlayById(player.id, accessToken ?? '', { ended: true });
+      await patchPlayById(player.id, tokens?.access_token || '', { ended: true });
       setAlertMessage(`Juego del estudiante ${player.student} terminado exitosamente.`);
       setOpenSuccess(true);
     } catch (error) {

--- a/src/components/EndPlayForAllButton/EndPlayForAllButton.tsx
+++ b/src/components/EndPlayForAllButton/EndPlayForAllButton.tsx
@@ -1,10 +1,11 @@
-import React, { CSSProperties, useEffect, useState } from 'react';
-import { ApiResponse, EndPlayResponse, Game } from '../../services/types';
+import { Button } from '@mui/material';
+import React, { CSSProperties, useState } from 'react';
 import { Loading } from '..';
 import { endPlaysById } from '../../services';
+import { ApiResponse, EndPlayResponse, Game } from '../../services/types';
+import { useAppContext } from '../../store/appContext/useAppContext';
 import { SnackbarComponent } from '../SnackbarComponent';
-import { Button } from '@mui/material';
-import "./EndPlayForAllButton.css"
+import "./EndPlayForAllButton.css";
 
 interface EndPlayForAllProps {
   cardGame: Game;
@@ -12,19 +13,11 @@ interface EndPlayForAllProps {
 }
 
 const EndPlayForAllButton: React.FC<EndPlayForAllProps> = ({ cardGame, style }) => {
+  const { tokens } = useAppContext();
   const [isLoading, setIsLoading] = useState<boolean>(false);
   const [alertMessage, setAlertMessage] = useState('');
-  const [accessToken, setAccessToken] = useState<string>('');
   const [openSuccess, setOpenSuccess] = useState(false);
   const [openError, setOpenError] = useState(false);
-
-  useEffect(() => {
-    const tokensString = localStorage.getItem('tokens');
-    if (tokensString) {
-      const tokens = JSON.parse(tokensString);
-      setAccessToken(tokens.access_token);
-    }
-  }, []);
 
   const handleClose = (key: 'success' | 'error') => (_event?: React.SyntheticEvent | Event, reason?: string) => {
     if (reason === 'clickaway') {
@@ -36,7 +29,7 @@ const EndPlayForAllButton: React.FC<EndPlayForAllProps> = ({ cardGame, style }) 
   const endPlayForAllHandle = async () => {
     try {
       setIsLoading(true);
-      const response: ApiResponse<EndPlayResponse> = await endPlaysById(cardGame.id, accessToken);
+      const response: ApiResponse<EndPlayResponse> = await endPlaysById(cardGame.id, tokens?.access_token || '');
 
       if (response.status === 200) {
         setAlertMessage('Juego terminado para todos');

--- a/src/components/SanctionButton/SanctionButton.tsx
+++ b/src/components/SanctionButton/SanctionButton.tsx
@@ -8,10 +8,11 @@ import { DatePicker } from '@mui/x-date-pickers/DatePicker';
 import { LocalizationProvider } from '@mui/x-date-pickers/LocalizationProvider';
 import dayjs, { Dayjs } from 'dayjs';
 import "dayjs/locale/es";
-import React, { useEffect, useState } from "react";
+import React, { useState } from "react";
 import { createSanction, patchPlayById } from "../../services";
 import { Play } from "../../services/types";
 import CustomModal from "../Modal/Modal";
+import { useAppContext } from "../../store/appContext/useAppContext";
 
 
 interface SanctionButtonProps {
@@ -20,9 +21,9 @@ interface SanctionButtonProps {
 }
 
 const SanctionButton: React.FC<SanctionButtonProps> = ({ player }) => {
+  const { tokens } = useAppContext();
   const [open, setOpen] = useState(false);
   const [alertMessage, setAlertMessage] = useState("");
-  const [accessToken, setAccessToken] = useState<string | undefined>(undefined);
   const [modalOpen, setModalOpen] = useState(false);
   const [endTime, setEndTime] = useState<Dayjs | null>(null);
   const [cause, setCause] = useState<string>("");
@@ -51,14 +52,6 @@ const SanctionButton: React.FC<SanctionButtonProps> = ({ player }) => {
     setModalOpen(false);
   };
 
-  useEffect(() => {
-    const tokensString = localStorage.getItem("tokens");
-    if (tokensString) {
-      const tokens = JSON.parse(tokensString);
-      setAccessToken(tokens.access_token);
-    }
-  }, []);
-
   const handlePerformSanction = async (event: React.FormEvent<HTMLFormElement>) => {
     event.preventDefault();
 
@@ -75,18 +68,15 @@ const SanctionButton: React.FC<SanctionButtonProps> = ({ player }) => {
     }
 
     try {
-      if (!accessToken) {
-        throw new Error("No access token found");
-      }
 
       await createSanction(
-        accessToken,
+        tokens?.access_token || '',
         cause ?? "",
         endTime.toJSON(),
         player.student,
         player.id,
       );
-      await patchPlayById(player.id, accessToken, { ended: true });
+      await patchPlayById(player.id, tokens?.access_token || '', { ended: true });
       setAlertMessage(`Jugador ${player.id} sancionado exitosamente.`);
       setOpen(true);
     } catch (error) {

--- a/src/pages/Home/Home.tsx
+++ b/src/pages/Home/Home.tsx
@@ -145,9 +145,7 @@ const Home = () => {
               <Card
                 key={game.id}
                 cardGame={game}
-                user={user}
-                shouldUpdate={game.needsUpdate || false}
-                onUpdated={() => resetUpdateFlagForGame(game.id)}
+                onUpdate={() => resetUpdateFlagForGame(game.id)}
                 sendMessage={(cardGameId: number) =>
                   sendUpdateMessage("Plays updated", user, cardGameId)
                 }

--- a/src/services/httpInstance.ts
+++ b/src/services/httpInstance.ts
@@ -1,5 +1,6 @@
 import axios from "axios";
 import Config from "../config";
+import { updateTokensHelper } from "../store/appContext/appContext";
 
 interface AxiosError {
   response?: {
@@ -33,7 +34,7 @@ httpInstance.interceptors.response.use(
         const response = await axios.post(`${Config.API_URL}token/refresh/`, { "refresh": refreshToken }, { headers: { 'Content-Type': 'application/json' } });
         const access = response.data.access;
 
-        localStorage.setItem('tokens', JSON.stringify({ access_token: access, refresh_token: refreshToken }));
+        if (updateTokensHelper) updateTokensHelper(access, refreshToken)
 
         // Retry the original request with the new token
         originalRequest.headers.Authorization = `Bearer ${access}`;

--- a/src/store/appContext/appContext.tsx
+++ b/src/store/appContext/appContext.tsx
@@ -2,6 +2,8 @@ import { createContext, useEffect, useState } from 'react';
 import { AppContextProps, AppState, Tokens, UserObject } from './types';
 import { Driver, driver } from 'driver.js';
 
+let updateTokensHelper: ((access: string, refresh: string) => void) | null = null;
+
 export const AppContext = createContext<AppState | undefined>(undefined);
 
 export const AppContextProvider = ({ children }: AppContextProps) => {
@@ -33,6 +35,7 @@ export const AppContextProvider = ({ children }: AppContextProps) => {
         setTokens(newTokens);
         localStorage.setItem('tokens', JSON.stringify(newTokens));
     };
+    updateTokensHelper = setTokensState;
 
     const logOut = () => {
         setUser(undefined);
@@ -73,3 +76,5 @@ export const AppContextProvider = ({ children }: AppContextProps) => {
         </AppContext.Provider>
     );
 }
+
+export { updateTokensHelper };


### PR DESCRIPTION
  The tokens were originally initialized by parsing localStorage values
  in each component's useEffect. Multiple components did this, so when
  the access token was refreshed via the Axios interceptor and the
  AppContext, the access token in these components was never updated.
  This caused multiple request retries.

  Now, the components use the tokens from AppContext, and the Axios
  interceptor also updates the context. CAUTION: This may still lead to
  errors in the future.